### PR TITLE
Gmail

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -134,10 +134,9 @@ class CompaniesController < ApplicationController
   # Deletes a company and emails the old contact.
   def destroy
     @company.companyevents.destroy_all
+    UserMailer.com_del(@company).deliver_now
     @company.destroy
     respond_to do |format|
-      # This was one use of the previous broken mailer. Replace this with the new mailer, and remove this comment.
-      UserMailer.com_del(@company).deliver_now
       format.html { redirect_to companies_url, notice: 'Company was successfully destroyed.' }
       format.json { head :no_content }
     end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -81,7 +81,7 @@ class CompaniesController < ApplicationController
         end
 
         # This was one use of the previous broken mailer. Replace this with the new mailer, and remove this comment.
-        # UserMailer.com_reg(@company).deliver_now
+        UserMailer.com_reg(@company).deliver_now
 
         format.html { redirect_to @company, notice: 'Company was successfully created.' }
         format.json { render :show, status: :created, location: @company }
@@ -112,7 +112,7 @@ class CompaniesController < ApplicationController
         end
         
         # This was one use of the previous broken mailer. Replace this with the new mailer, and remove this comment.
-        # UserMailer.com_reg(@company).deliver_now
+        UserMailer.com_reg(@company).deliver_now
         
         format.html { redirect_to @company, notice: 'Company was successfully updated.' }
         format.json { render :show, status: :ok, location: @company }
@@ -137,7 +137,7 @@ class CompaniesController < ApplicationController
     @company.destroy
     respond_to do |format|
       # This was one use of the previous broken mailer. Replace this with the new mailer, and remove this comment.
-      # UserMailer.com_del(@company).deliver_now
+      UserMailer.com_del(@company).deliver_now
       format.html { redirect_to companies_url, notice: 'Company was successfully destroyed.' }
       format.json { head :no_content }
     end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -182,7 +182,7 @@ class StudentsController < ApplicationController
           $stu_slot[x.id] = @arr
         end
 
-        # UserMailer.stu_reg(@student).deliver_now
+        UserMailer.stu_reg(@student).deliver_now
 
         format.html { redirect_to @student, notice: %Q[ Student was successfully created. #{view_context.link_to("Edit Link", get_edit_url(@student))} ], flash: { html_safe: true } }
         format.json { render :show, status: :created, location: @student }
@@ -227,7 +227,7 @@ class StudentsController < ApplicationController
       
       # Ensure that the student was updated
       if @student.update(student_params)
-        # UserMailer.stu_reg(@student).deliver_now
+        UserMailer.stu_reg(@student).deliver_now
 	      Timeslot.decrease_1(@student.id)
         
         if not (log_in? && cus_indentify(get_id))
@@ -255,7 +255,7 @@ class StudentsController < ApplicationController
   def destroy
     @student.destroy
     respond_to do |format|
-      # UserMailer.stu_del(@student).deliver_now
+      UserMailer.stu_del(@student).deliver_now
       format.html { redirect_to students_url, notice: 'Student was successfully destroyed.' }
       format.json { head :no_content }
     end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -253,9 +253,9 @@ class StudentsController < ApplicationController
   # DELETE /students/1.json
   # Deletes the current student
   def destroy
+    UserMailer.stu_del(@student).deliver_now
     @student.destroy
     respond_to do |format|
-      UserMailer.stu_del(@student).deliver_now
       format.html { redirect_to students_url, notice: 'Student was successfully destroyed.' }
       format.json { head :no_content }
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   
-  config.action_mailer.default_url_options = { :host => "peaceful-harbor-1149.herokuapp.com" }
+  config.action_mailer.default_url_options = { :host => "iap-scheduler-csce@herokuapp.com" }
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
       :address => "smtp.gmail.com",


### PR DESCRIPTION
Reconfigured host to match the new heroku deployment and uncommented all lines in the "student" and "companies" controllers related to the actionmailer. Configured gmail account "no.reply.cse.careerfair.tamu@gmail.com" to allow usage by the heroku app "iap-scheduler-csce.herokuapp.com." Check readme for instructions on how to reconfigure with another heroku app.